### PR TITLE
CRLF breaks /usr/bin/env

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,7 +24,7 @@ var log = {
 	'info': console.info.bind(console),
 	'debug': console.log.bind(console),
 	'trace': console.trace.bind(console),
-}
+};
 
 var url = program.args[0];
 program.output = program.output || 'table';


### PR DESCRIPTION
Fixes #8 (hopefully)
PS: git won't show the conversion, that's why i had to add that semicolon.
