### PR TITLE
Make JSON output actual JSON

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,7 +35,7 @@ require('./index.js')(url, function(err, data) {
 		if (program.output === 'table') {
 			log.info(generateTable(data));
 		} else {
-			log.info(data);
+			log.info(JSON.stringify(data));
 		}
 	}
 }, {


### PR DESCRIPTION
Previously, just using the `info` on a JS object gives interpretable JS, but it's not JSON. Piping this into jq was breaking, and I <3 jq, and this was all it took to get valid JSON.
