### PR TITLE
Fix chrome driver issue by convert deprecated timeline setting

### DIFF
--- a/lib/metrics/TimelineMetrics.js
+++ b/lib/metrics/TimelineMetrics.js
@@ -20,7 +20,7 @@ TimelineMetrics.prototype.setup = function(cfg) {
 		helpers.extend(browser, {
 			chromeOptions: {
 				perfLoggingPrefs: {
-					enableTimeline: true
+					'traceCategories': 'blink.console,disabled-by-default-devtools.timeline'
 				}
 			}
 		});


### PR DESCRIPTION
Use new traceCategories : 'disabled-by-default-devtools.timeline'

See https://github.com/angular/angular/issues/434
Which points to example https://github.com/jeffbcross/benchpress-tree/blob/master/protractor.conf.js#L6