### PR TITLE
NetworkResources Performance Metric

### DIFF
--- a/docs/NetworkResources.json
+++ b/docs/NetworkResources.json
@@ -1,0 +1,258 @@
+{
+  "NetworkImage": {
+    "type": "total",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "The time spent to load all images from page and CSS",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkImage_avg": {
+    "type": "average",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Average time spent to load one images",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkImage_count": {
+    "type": "count",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Total number of images loaded",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkImage_max": {
+    "type": "max",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Maximum image loading duration",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+
+  "NetworkIframe": {
+    "type": "total",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "The time spent to load all iframes on page",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkIframe_avg": {
+    "type": "average",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Average time spent to load one iframe",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkIframe_count": {
+    "type": "count",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Total number of iframes loaded",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkIframe_max": {
+    "type": "max",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Maximum iframe loading duration",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+
+  "NetworkCss": {
+    "type": "total",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "The time spent to load all CSS resources on page",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkCss_avg": {
+    "type": "average",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Average time spent to load one CSS file",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkCss_count": {
+    "type": "count",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Total number of CSS files loaded",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkCss_max": {
+    "type": "max",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Maximum CSS file loading duration",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+
+  "NetworkJs": {
+    "type": "total",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "The time spent to load all JS resources on page",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkJs_avg": {
+    "type": "average",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Average time spent to load one JS file",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkJs_count": {
+    "type": "count",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Total number of JS files loaded",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkJs_max": {
+    "type": "max",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Maximum JS file loading duration",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+
+  "NetworkXhrrequest": {
+    "type": "total",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "The time spent to load all XHR Requests on page",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkXhrrequest_avg": {
+    "type": "average",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Average time spent to load one XHR Request",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkXhrrequest_count": {
+    "type": "count",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Total number of XHR Request loaded",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkXhrrequest_max": {
+    "type": "max",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Maximum XHR Request loading duration",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+
+  "NetworkOther": {
+    "type": "total",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "The time spent to load all non-categorised page resources, f.e. icons",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkOther_avg": {
+    "type": "average",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Average time spent to load one non-categorised resource",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkOther_count": {
+    "type": "count",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Total number of non-categorised resources loaded",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+  "NetworkOther_max": {
+    "type": "max",
+    "tags": ["Network"],
+    "unit": "ms",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Maximum non-categorised resource loading duration",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  },
+
+  "NetworkRawData" : {
+    "type": "tottal",
+    "tags": ["Network"],
+    "unit": "",
+    "source": "NetworkResources",
+    "variance": 0.5,
+    "summary": "Raw response from window.performance",
+    "details": "",
+    "browsers": ["chrome", "firefox", "android"]
+  }
+}

--- a/lib/metrics/NetworkResources.js
+++ b/lib/metrics/NetworkResources.js
@@ -1,0 +1,108 @@
+var BaseMetrics = require('./BaseMetrics'),
+    helpers = require('../helpers'),
+    StatData = require('./util/StatData'),
+    Q = require('q');
+
+function NetworkResources() {
+
+    /**
+     * "outputRawData" config option to decide whether or not Metric should return raw data
+     *
+     * "resultsBeforeStart" window.performance.getEntries() track all resources, even before browser-perf is started.
+     * With this option, metric could return all ("true") results or only between Probe "start" and "teardown" ("false")
+     *
+     * @type {{outputRawData: boolean, resultsBeforeStart: boolean}}
+     */
+    this.defaultOptions = {
+        'outputRawData' : false,
+        'resultsBeforeStart' : false
+    };
+
+    // Initialize result statistics object
+    this.stats = {};
+
+    // Check http://www.w3.org/TR/resource-timing/ for available types
+    this.typesMapping = {
+        'subdocument' : 'iframe',
+        'iframe' : 'iframe',
+        'img' : 'image',
+        'link' : 'css',
+        'script' : 'js',
+        'css' : 'image', //mean resource is loaded from CSS file
+        'xmlhttprequest' : 'xhrrequest'
+    };
+
+    BaseMetrics.apply(this, arguments);
+}
+require('util').inherits(NetworkResources, BaseMetrics);
+
+NetworkResources.prototype.id = 'NetworkResources';
+NetworkResources.prototype.probes = ['NetworkResourcesProbe'];
+
+/**
+ * Metrics setup
+ * Extend default configuration options
+ *
+ * @param config
+ * @returns {*}
+ */
+NetworkResources.prototype.setup = function (config) {
+    var options = config.metricOptions[this.id] || {};
+    this.options = helpers.extend(this.defaultOptions, options);
+
+    return Q(config);
+};
+
+NetworkResources.prototype.onData = function(data) {
+    this.resources = data;
+    this.resources.forEach(function(element) {
+        this.addData(element);
+    }, this);
+};
+
+/**
+ * Calculate type based on resource properties and add it to stats
+ *
+ * @param row
+ */
+NetworkResources.prototype.addData = function(row) {
+
+    var type = this.typesMapping[row['initiatorType']] || 'other';
+    var statsKey = 'Network' + type[0].toUpperCase() + type.slice(1);
+
+    if (typeof this.stats[statsKey] === 'undefined') {
+        this.stats[statsKey] = new StatData();
+    }
+
+    this.stats[statsKey].add(row['duration']);
+};
+
+/**
+ * Calculate results for Networking Resources usage
+ *
+ * @returns {object}
+ */
+NetworkResources.prototype.getResults = function() {
+
+    var result = {};
+
+    for (var key in this.stats) {
+        var stats = this.stats[key].getStats();
+        if (stats.sum === 0) {
+            result[key] = stats.count;
+        } else {
+            result[key] = stats.sum;
+            result[key + '_avg'] = stats.mean;
+            result[key + '_max'] = stats.max;
+            result[key + '_count'] = stats.count;
+        }
+    }
+
+    if (this.options.outputRawData) {
+        result['NetworkRawData'] = this.resources || [];
+    }
+
+    return result;
+};
+
+module.exports = NetworkResources;

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -84,5 +84,6 @@ module.exports.builtIns = [
 	'RafRenderingStats',
 	'NetworkTimings',
 	'TimelineMetrics',
-	'ChromeTracingMetrics'
-]
+	'ChromeTracingMetrics',
+    'NetworkResources'
+];

--- a/lib/options.js
+++ b/lib/options.js
@@ -175,8 +175,19 @@ var sanitizers = [
 			opts.metrics = [opts.metrics];
 		}
 		return opts;
-	}
-]
+	},
+
+    /**
+     * Metric options
+     *
+     * @example opts.metricOptions = { "METRIC_ID" : { option1 : value1, ... , optionN : valueN } }
+     * @param {object} opts
+     */
+        function (opts) {
+        opts.metricOptions = opts.metricOptions || {};
+        return opts;
+    }
+];
 
 
 module.exports = {

--- a/lib/probes/NetworkResourcesProbe.js
+++ b/lib/probes/NetworkResourcesProbe.js
@@ -1,0 +1,101 @@
+var Q = require('q'),
+    util = require('util'),
+    wd = require('wd'),
+    events = require('events'),
+    helpers = require('../helpers');
+
+/**
+ * Network resources timing Probe
+ *
+ * @see http://www.w3.org/TR/resource-timing/
+ * @constructor
+ */
+function NetworkResourcesProbe() {
+
+    /**
+     * "outputRawData" config option to decide whether or not Metric should return raw data
+     *
+     * "resultsBeforeStart" window.performance.getEntries() track all resources, even before browser-perf is started.
+     * With this option, metric could return all ("true") results or only between Probe "start" and "teardown" ("false")
+     *
+     * @type {{outputRawData: boolean, resultsBeforeStart: boolean}}
+     */
+    this.defaultOptions = {
+        'outputRawData' : false,
+        'resultsBeforeStart' : false
+    };
+
+    this.lastResourceTime = 0;
+
+    events.EventEmitter.call(this);
+}
+
+util.inherits(NetworkResourcesProbe, events.EventEmitter);
+
+NetworkResourcesProbe.prototype.id = 'NetworkResourcesProbe';
+
+/**
+ * Client-side script that need to be executed
+ * inside browser to get Network Resources statistics
+ *
+ * @private
+ */
+NetworkResourcesProbe.prototype._clientGetData = function() {
+    window.__networkResources = (window.performance && typeof window.performance.getEntries == 'function')
+        ? window.performance.getEntries()
+        : [];
+};
+
+NetworkResourcesProbe.prototype.setup = function(config) {
+    var options = config.metricOptions['NetworkResources'] || {};
+    this.options = helpers.extend(this.defaultOptions, options);
+};
+
+/**
+ * Called on metrics.stats
+ *
+ * @param browser
+ */
+NetworkResourcesProbe.prototype.start = function(browser) {
+    var me = this;
+
+    // Execute window.performance.getEntries() to get resources
+    // that were before fetched before browser-perf metrics started
+    // and calculate last loaded resource
+    browser.execute(helpers.fnCall(this._clientGetData))
+        .then(function() {
+            return browser.eval('window.__networkResources')
+        })
+        .then(function(res) {
+            me.beforeData = res;
+
+            // If "resultsBeforeStart" option is false and there are any information
+            if (!me.options.resultsBeforeStart &&  me.beforeData && me.beforeData.length > 0) {
+                me.lastResourceTime = me.beforeData[me.beforeData.length - 1]['responseEnd'];
+            }
+        });
+};
+
+/**
+ * Called on metrics.teardown
+ *
+ * @param browser
+ * @returns {*}
+ */
+NetworkResourcesProbe.prototype.teardown = function(browser) {
+    var me = this;
+    return browser.execute(helpers.fnCall(this._clientGetData))
+        .then(function() {
+            return browser.eval('window.__networkResources')
+        })
+        .then(function(res) {
+            // filter results to starts with this.lastResourceTime
+            return res.filter(function(element) {
+                return element['startTime'] >= me.lastResourceTime
+            });
+        })
+        .then(function(res) {
+            me.emit('data', res);
+        });
+};
+module.exports = NetworkResourcesProbe;


### PR DESCRIPTION
Adding new Metric to tracking network activity while test is running. Metric Probe uses http://www.w3.org/TR/resource-timing/ Resource API to track resources loaded by application.
This API supports in Chrome and Firefox and latest IE (http://caniuse.com/#search=resource)

Metric results will be number of files and time that take to load each resource for the application split by resources types - CSS, JS, XHRRequest, Image and e.t.c

By default, NetworkResources metric is not enabled, this metric could be enabled via configuration file.

Metric supports 2 options
- should metric return raw data output or not
- should count resources before metrics collected was started or not (before metrics.start called)

Default values
```
{
...
"metricOptions" : {
        "outputRawData" : false,
        "resultsBeforeStart" : false
    }
...
}
```

If raw data option is enabled - output will contain "NetworkRawData" entry with all information probe received from browser. This option is helpful if developer want to build "Networking Panel" from results that browser-perf library can provide.

Any feedback or review is much appreciated 