### PR TITLE
Fix -  Network resources should process only resources

### DIFF
--- a/lib/metrics/NetworkResources.js
+++ b/lib/metrics/NetworkResources.js
@@ -56,7 +56,10 @@ NetworkResources.prototype.setup = function (config) {
 NetworkResources.prototype.onData = function(data) {
     this.resources = data;
     this.resources.forEach(function(element) {
-        this.addData(element);
+        // Process only "resource" type results, so we do not add "marks" and "measures" into StatData
+        if (element['entryType'] && element['entryType'] === 'resource') {
+            this.addData(element);
+        }
     }, this);
 };
 


### PR DESCRIPTION
Fix -  Network resources should process only resources

Process only "resource" type results, so we do not add "marks" and "measures" into StatData.
F.e. if some client-side code use window.performance.mark() or window.performance.measure() while Browser-Perf enabled - those API call will stored in "NetworkOther" stats and this is incorrect behaviour. 