### PR TITLE
Set lastResourceTime to max of response ends

### DIFF
--- a/lib/probes/NetworkResourcesProbe.js
+++ b/lib/probes/NetworkResourcesProbe.js
@@ -71,7 +71,8 @@ NetworkResourcesProbe.prototype.start = function(browser) {
 
             // If "resultsBeforeStart" option is false and there are any information
             if (!me.options.resultsBeforeStart &&  me.beforeData && me.beforeData.length > 0) {
-                me.lastResourceTime = me.beforeData[me.beforeData.length - 1]['responseEnd'];
+                var resourceTimes = me.beforeData.map(function(networkResource, idx) { return networkResource.responseEnd; });
+                me.lastResourceTime = Math.max.apply(null, resourceTimes);
             }
         });
 };


### PR DESCRIPTION
Last resource time is currently being set to the end response of the last resource in the array. 

These resources are not ordered by when their response ends though:
![image](https://cloud.githubusercontent.com/assets/1745854/9239621/78c513ba-4112-11e5-94fa-953b59a9c67f.png)

(Number on the left is the resource index, number on the right is the `responseEnd` value.)

`lastResourceTime` should be set the the last `responseEnd` time, rather then the `responseEnd` of the last resource in the array.

The previous code would set `lastResourceTime` to `1324.06...`
The new code would set `lastResourceTime` to `1325.53...`