### PR TITLE
Do not add `chromeOptions` unless required

### DIFF
--- a/lib/metrics/TimelineMetrics.js
+++ b/lib/metrics/TimelineMetrics.js
@@ -23,15 +23,14 @@ var eventCategoryRegEx = new RegExp('\\b(' + TRACE_CATEGORIES.join('|') + '|__me
 
 TimelineMetrics.prototype.setup = function(cfg) {
     cfg.browsers = cfg.browsers.map(function(browser) {
-        helpers.extend(browser, {
-            chromeOptions: {
-                perfLoggingPrefs: {}
-            }
-        });
-
         if (helpers.deepEquals(browser, 'browserName', 'chrome') ||
             (helpers.deepEquals(browser, 'browserName', 'android') && !helpers.deepEquals(browser, 'chromeOptions.androidPackage', 'com.android.chrome'))) {
             // Only add this for Chrome OR Android-hybrid, not for Android-Chrome
+            helpers.extend(browser, {
+                chromeOptions: {
+                    perfLoggingPrefs: {}
+                }
+            });
             browser.chromeOptions.perfLoggingPrefs.traceCategories = [
                 browser.chromeOptions.perfLoggingPrefs.traceCategories || '',
                 TRACE_CATEGORIES


### PR DESCRIPTION
This prevents an issue with selenium trying to use the chrome driver for other browser configs.

I had the following config for the `browsers` section:

```
browsers: [{ // This can also be a ["chrome", "firefox"] or "chrome,firefox"
      browserName: 'chrome',
      chromeOptions: {args: ['--headless', 'window-size=800x400']}
    }, {
      browserName: 'firefox',
      'moz:firefoxOptions': {args: ['--headless']}
    }, {
      browserName: 'safari'
    }]
```

But no matter what I tried to do, it would always try to launch chrome for `firefox` and `safari`. After some googling I stumbled upon [this comment](https://github.com/nightwatchjs/nightwatch/issues/1571#issuecomment-361604017) which pointed me at the `chromeOptions` as being the culprit.

```
~ » selenium-server --version
Selenium server version: 3.9.0, revision: 698b3178f0
~ » chromedriver --version
ChromeDriver 2.35.528157 (4429ca2590d6988c0745c24c8858745aaaec01ef)
~ » geckodriver --version
geckodriver 0.19.1
```