### PR TITLE
Do not make an extra call to fetch logs

### DIFF
--- a/lib/probes/PerfLogProbe.js
+++ b/lib/probes/PerfLogProbe.js
@@ -34,10 +34,6 @@ PerfLogProbe.prototype.start = function(browser) {
 	return browser.logTypes().then(function(logs) {
 		debug('Supported log types', logs);
 		me.enabled = (logs.indexOf('performance') !== -1);
-	}).then(function() {
-		if (me.enabled) {
-			return browser.log('performance');
-		}
 	});
 };
 


### PR DESCRIPTION
This seems to cause an issue with the chromedriver.

In regards to [this comment](https://github.com/axemclion/browser-perf/issues/43#issuecomment-364468846).
After some more stumbling around and googling I tracked down [this issue](https://github.com/SeleniumHQ/selenium/issues/4530) which hints at multiple calls to performance logs leaves out trace info. Turns out there is a call to fetch the performance logs prior to setting up the log stream. I removed this call and got the tracing info. 

I ran the unit tests after this change and did not see a negative impact. I'm not sure if there is something I'm missing that requires this call.